### PR TITLE
Update compiler configuration to Java 21

### DIFF
--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -9,10 +9,9 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.13.0</version>
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <release>21</release>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Summary
- configure the Maven compiler plugin to target Java 21 using the `<release>` flag for the utilities module

## Testing
- mvn -q test *(fails: unable to download org.apache.maven.plugins:maven-resources-plugin:3.3.1 due to HTTP 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_69079addcdc88328a58f78263ba23f61