### PR TITLE
Add crap4java quality gate

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: pr-tests-${{ github.event.pull_request.number || github.ref }}

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>media.barney</groupId>
-  <artifactId>utils-java</artifactId>
+  <artifactId>barney-utils</artifactId>
   <version>0.0.1-SNAPSHOT</version>
-  <name>Utils (Java)</name>
+  <name>Barney Utils</name>
   <description>Utility classes you do not want to miss in any project.</description>
   <properties>
     <crap4java.version>0.1.2</crap4java.version>


### PR DESCRIPTION
## Summary
- add the shared crap4java Maven plugin to the build
- configure CI to resolve the plugin from GitHub Packages
- keep the gate on the existing erify workflow path

## Testing
- ./mvnw -B -ntp verify