### PR TITLE
Rename Maven metadata to utils-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>media.barney</groupId>
-  <artifactId>barney-utils</artifactId>
+  <artifactId>utils-java</artifactId>
   <version>0.0.1-SNAPSHOT</version>
-  <name>Barney Utils</name>
+  <name>utils-java</name>
   <description>Utility classes you do not want to miss in any project.</description>
   <properties>
     <crap4java.version>0.1.2</crap4java.version>


### PR DESCRIPTION
## Implementation Summary
- Scope: align Maven project metadata with the `utils-java` naming now used by the artifact.
- Key changes: rename the root `artifactId` to `utils-java` and update the project `<name>` to `utils-java`.
- Non-goals: no code, dependency, or behavior changes.

## Validation
- Tests executed: not run; metadata-only POM update.
- Manual checks: inspected the root `pom.xml` after the change.
- Residual risks: low; downstream publishing or consumers that still expect the previous artifact coordinates would need to use the new artifactId.