### PR TITLE
Make Crap4Java workflow explicit

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -20,6 +20,9 @@ jobs:
   test:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout
@@ -31,6 +34,9 @@ jobs:
           distribution: temurin
           java-version: "21"
           cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
 
       - name: Run Maven test
         run: ./mvnw -B -ntp test


### PR DESCRIPTION
## Summary
- split tests and crap4java into separate GitHub Actions jobs
- run the dedicated Crap4Java Gate job via the direct crap4java:check goal
- keep the gate status visible independently from the regular Maven test job

## Testing
- ./mvnw -B -ntp test
- ./mvnw -B -ntp crap4java:check