### PR TITLE
Adopt crap-java 0.2.0

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Run Maven test
         run: ./mvnw -B -ntp test
 
-  crap4java:
-    name: Crap4Java Gate
+  crap-java:
+    name: crap-java Gate
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     env:
@@ -63,5 +63,5 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
-      - name: Run Crap4Java gate
-        run: ./mvnw -B -ntp crap4java:check
+      - name: Run crap-java gate
+        run: ./mvnw -B -ntp crap-java:check

--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
   <name>utils-java</name>
   <description>Utility classes you do not want to miss in any project.</description>
   <properties>
-    <crap4java.version>0.1.2</crap4java.version>
+    <crap-java.version>0.2.0</crap-java.version>
   </properties>
   <pluginRepositories>
     <pluginRepository>
       <id>github</id>
-      <url>https://maven.pkg.github.com/fabian-barney/crap4java</url>
+      <url>https://maven.pkg.github.com/fabian-barney/crap-java</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>
@@ -41,8 +41,8 @@
       </plugin>
       <plugin>
         <groupId>media.barney</groupId>
-        <artifactId>crap4java-maven-plugin</artifactId>
-        <version>${crap4java.version}</version>
+        <artifactId>crap-java-maven-plugin</artifactId>
+        <version>${crap-java.version}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
## Summary
- adopt the released `crap-java` `0.2.0` Maven plugin coordinates and package URL
- rename the local property and workflow command from `crap4java` to `crap-java`
- keep the existing PR test split while pointing the CRAP gate at `crap-java:check`

## Testing
- `./mvnw -B -ntp test`
- `./mvnw -B -ntp crap-java:check`

Closes #19