### PR TITLE
Publish Maven Central release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
       CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-      CENTRAL_GPG_PASSPHRASE: ${{ secrets.CENTRAL_GPG_PASSPHRASE }}
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.CENTRAL_GPG_PASSPHRASE }}
 
     steps:
       - name: Checkout
@@ -51,7 +51,7 @@ jobs:
           java-version: "21"
           cache: maven
           gpg-private-key: ${{ secrets.CENTRAL_GPG_PRIVATE_KEY }}
-          gpg-passphrase: CENTRAL_GPG_PASSPHRASE
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Write Maven settings.xml
         shell: bash
@@ -77,4 +77,4 @@ jobs:
           EOF
 
       - name: Publish release
-        run: ./mvnw -B -ntp -Prelease -Drevision=${{ steps.version.outputs.version }} -Dcentral.skipPublishing=false deploy
+        run: ./mvnw -B -ntp -Prelease -Drevision=${{ steps.version.outputs.version }} -Dscm.tag=v${{ steps.version.outputs.version }} -Dcentral.skipPublishing=false deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release to Maven Central
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_ACTOR: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+      CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
+      CENTRAL_GPG_PASSPHRASE: ${{ secrets.CENTRAL_GPG_PASSPHRASE }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          if [[ -z "$version" || "$version" == "$GITHUB_REF_NAME" ]]; then
+            echo "Tags must be prefixed with 'v', for example v0.1.0." >&2
+            exit 1
+          fi
+          if [[ "$version" == *-SNAPSHOT ]]; then
+            echo "Release versions must not end in -SNAPSHOT." >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: maven
+          gpg-private-key: ${{ secrets.CENTRAL_GPG_PRIVATE_KEY }}
+          gpg-passphrase: CENTRAL_GPG_PASSPHRASE
+
+      - name: Write Maven settings.xml
+        shell: bash
+        run: |
+          mkdir -p "${HOME}/.m2"
+          cat > "${HOME}/.m2/settings.xml" <<'EOF'
+          <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${env.GITHUB_ACTOR}</username>
+                <password>${env.GITHUB_TOKEN}</password>
+              </server>
+              <server>
+                <id>central</id>
+                <username>${env.CENTRAL_USERNAME}</username>
+                <password>${env.CENTRAL_PASSWORD}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
+
+      - name: Publish release
+        run: ./mvnw -B -ntp -Prelease -Drevision=${{ steps.version.outputs.version }} -Dcentral.skipPublishing=false deploy

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+.flattened-pom.xml
 .classpath
 .project
 .settings/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ double bits = ByteUnit.KIB.toBits(4, 16);
 - Byte-to-bit conversions assume 8 bits per byte by default.
 - The conversion helpers include overflow guards for multiplication-heavy paths.
 
+## Release
+
+See `RELEASING.md` for the Maven Central release workflow, required GitHub
+secrets, and rollback expectations.
+
 ## License
 
 Apache License 2.0. See `LICENSE`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -42,7 +42,7 @@ overrides `revision` during tagged releases.
 You can validate the release profile locally without publishing by running:
 
 ```powershell
-.\mvnw.cmd -B -ntp -Prelease -Drevision=0.1.0 -Dcentral.skipPublishing=true deploy
+.\mvnw.cmd -B -ntp -Prelease -Drevision=0.1.0 -Dscm.tag=v0.1.0 -Dcentral.skipPublishing=true deploy
 ```
 
 This still requires:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,62 @@
+# Releasing
+
+`utils-java` publishes non-`SNAPSHOT` releases to Maven Central through the
+Central Publisher Portal.
+
+## Prerequisites
+
+Before the release workflow can succeed:
+
+- the `media.barney` namespace must be verified in the Central Publisher Portal
+- a Central Portal user token must be generated for the publishing account
+- a GPG key pair must exist and the public key must be published to a supported
+  keyserver
+
+## GitHub Secrets
+
+Configure these repository secrets:
+
+- `CENTRAL_USERNAME`: Central Publisher Portal user token username
+- `CENTRAL_PASSWORD`: Central Publisher Portal user token password
+- `CENTRAL_GPG_PRIVATE_KEY`: ASCII-armored private key used to sign artifacts
+- `CENTRAL_GPG_PASSPHRASE`: passphrase for the private key
+
+The workflow also uses the built-in `GITHUB_TOKEN` to resolve the
+`crap-java-maven-plugin` from GitHub Packages.
+
+## Release Process
+
+1. Make sure `main` contains the release-ready code.
+2. Create an annotated tag using the release version prefixed with `v`, for
+   example `v0.1.0`.
+3. Push the tag to GitHub.
+4. The `Release to Maven Central` workflow derives the Maven version from the
+   tag, runs `./mvnw -Prelease deploy`, signs the artifacts, and publishes them
+   via the Central Publisher Portal.
+
+The project keeps `0.0.1-SNAPSHOT` as the default local development version and
+overrides `revision` during tagged releases.
+
+## Local Dry Run
+
+You can validate the release profile locally without publishing by running:
+
+```powershell
+.\mvnw.cmd -B -ntp -Prelease -Drevision=0.1.0 -Dcentral.skipPublishing=true deploy
+```
+
+This still requires:
+
+- a usable GPG private key in the local keyring
+- access to GitHub Packages for the `crap-java-maven-plugin`
+
+## Rollback Expectations
+
+Maven Central is immutable. Once a version is published, do not reuse or
+overwrite it.
+
+If a release fails before the publish step completes, fix the workflow inputs or
+configuration and publish a new version.
+
+If a bad version is already visible on Maven Central, publish a newer version
+with the fix and leave the original artifact in place.

--- a/pom.xml
+++ b/pom.xml
@@ -27,10 +27,11 @@
     <connection>scm:git:https://github.com/fabian-barney/utils-java.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/fabian-barney/utils-java.git</developerConnection>
     <url>https://github.com/fabian-barney/utils-java</url>
-    <tag>v${project.version}</tag>
+    <tag>${scm.tag}</tag>
   </scm>
   <properties>
     <revision>0.0.1-SNAPSHOT</revision>
+    <scm.tag>HEAD</scm.tag>
     <crap-java.version>0.2.0</crap-java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -160,6 +161,7 @@
               </execution>
             </executions>
             <configuration>
+              <passphraseEnvName>MAVEN_GPG_PASSPHRASE</passphraseEnvName>
               <gpgArguments>
                 <arg>--pinentry-mode</arg>
                 <arg>loopback</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,49 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>media.barney</groupId>
   <artifactId>utils-java</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>${revision}</version>
   <name>utils-java</name>
   <description>Utility classes you do not want to miss in any project.</description>
+  <url>https://github.com/fabian-barney/utils-java</url>
+  <licenses>
+    <license>
+      <name>Apache License 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <id>fabian-barney</id>
+      <name>Fabian Barney</name>
+      <email>fabian.barney@barney-media.com</email>
+      <url>https://github.com/fabian-barney</url>
+    </developer>
+  </developers>
+  <scm>
+    <connection>scm:git:https://github.com/fabian-barney/utils-java.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/fabian-barney/utils-java.git</developerConnection>
+    <url>https://github.com/fabian-barney/utils-java</url>
+    <tag>v${project.version}</tag>
+  </scm>
   <properties>
+    <revision>0.0.1-SNAPSHOT</revision>
     <crap-java.version>0.2.0</crap-java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <maven.compiler.release>21</maven.compiler.release>
+    <flatten.maven.plugin.version>1.7.3</flatten.maven.plugin.version>
+    <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
+    <maven.javadoc.plugin.version>3.11.2</maven.javadoc.plugin.version>
+    <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
+    <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
+    <central.publishing.plugin.version>0.10.0</central.publishing.plugin.version>
+    <central.autoPublish>true</central.autoPublish>
+    <central.waitUntil>published</central.waitUntil>
+    <central.skipPublishing>true</central.skipPublishing>
   </properties>
   <pluginRepositories>
     <pluginRepository>
@@ -30,7 +65,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.15.0</version>
         <configuration>
-          <release>21</release>
+          <release>${maven.compiler.release}</release>
         </configuration>
       </plugin>
       <plugin>
@@ -55,4 +90,114 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>${flatten.maven.plugin.version}</version>
+            <configuration>
+              <flattenMode>oss</flattenMode>
+              <updatePomFile>true</updatePomFile>
+            </configuration>
+            <executions>
+              <execution>
+                <id>flatten-consumer-pom</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>clean-flattened-pom</id>
+                <phase>clean</phase>
+                <goals>
+                  <goal>clean</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>${maven.source.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${maven.javadoc.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>${maven.gpg.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <gpgArguments>
+                <arg>--pinentry-mode</arg>
+                <arg>loopback</arg>
+              </gpgArguments>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>${maven.enforcer.plugin.version}</version>
+            <executions>
+              <execution>
+                <id>require-release-version</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireReleaseVersion />
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${central.publishing.plugin.version}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>${central.autoPublish}</autoPublish>
+              <waitUntil>${central.waitUntil}</waitUntil>
+              <skipPublishing>${central.skipPublishing}</skipPublishing>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/src/main/java/media/barney/utils/unit/BitUnit.java
+++ b/src/main/java/media/barney/utils/unit/BitUnit.java
@@ -28,10 +28,7 @@ package media.barney.utils.unit;
  */
 public enum BitUnit {
 
-        /** <pre>
-         * Bit (bit)
-         * 1 Bit
-         */
+        /** Bit, equal to 1 bit. */
         BIT {
 		@Override
 		public double toBits(double d) { return UnitInputValidator.requireNonNegativeFinite(d); }
@@ -44,10 +41,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Kibibit (Kibit)
-         * 2^10 Bit = 1.024 Bit
-         */
+        /** Kibibit (Kibit), equal to 2^10 bits. */
         KIBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_KIBIT); }
@@ -60,10 +54,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Mebibit (Mibit)
-         * 2^20 Bit = 1.024 * 1.024 Bit = 1.048.576 Bit
-         */
+        /** Mebibit (Mibit), equal to 2^20 bits. */
         MIBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_MIBIT); }
@@ -76,10 +67,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Gibibit (Gibit)
-         * 2^30 Bit = 1.024 * 1.024 * 1.024 Bit = 1.073.741.824 Bit
-         */
+        /** Gibibit (Gibit), equal to 2^30 bits. */
         GIBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_GIBIT); }
@@ -92,10 +80,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Tebibit (Tibit)
-         * 2^40 Bit = 1.024 * 1.024 * 1.024 * 1.024 Bit = 1.099.511.627.776 Bit
-         */
+        /** Tebibit (Tibit), equal to 2^40 bits. */
         TIBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_TIBIT); }
@@ -108,10 +93,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Pebibit (Pibit)
-         * 2^50 Bit = 1.024 * 1.024 * 1.024 * 1.024 * 1.024 Bit = 1.125.899.906.842.624 Bit
-         */
+        /** Pebibit (Pibit), equal to 2^50 bits. */
         PIBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_PIBIT); }
@@ -124,10 +106,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Kilobit (kbit)
-         * 10^3 Bit = 1.000 Bit
-         */
+        /** Kilobit (kbit), equal to 10^3 bits. */
         KBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_KBIT); }
@@ -140,10 +119,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Megabit (Mbit)
-         * 10^6 Bit = 1.000.000 Bit
-         */
+        /** Megabit (Mbit), equal to 10^6 bits. */
         MBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_MBIT); }
@@ -156,10 +132,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Gigabit (Gbit)
-         * 10^9 Bit = 1.000.000.000 Bit
-         */
+        /** Gigabit (Gbit), equal to 10^9 bits. */
         GBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_GBIT); }
@@ -172,10 +145,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Terabit (Tbit)
-         * 10^12 Bit = 1.000.000.000.000 Bit
-         */
+        /** Terabit (Tbit), equal to 10^12 bits. */
         TBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_TBIT); }
@@ -188,10 +158,7 @@ public enum BitUnit {
 		}
 	},
 
-        /** <pre>
-         * Petabit (Pbit)
-         * 10^15 Bit = 1.000.000.000.000.000 Bit
-         */
+        /** Petabit (Pbit), equal to 10^15 bits. */
         PBIT {
 		@Override
 		public double toBits(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_PBIT); }

--- a/src/main/java/media/barney/utils/unit/ByteUnit.java
+++ b/src/main/java/media/barney/utils/unit/ByteUnit.java
@@ -32,10 +32,7 @@ package media.barney.utils.unit;
  */
 public enum ByteUnit {
 
-	/** <pre>
-	 * Byte (B)
-	 * 1 Byte
-	 */
+	/** Byte (B), equal to 1 byte. */
 	BYTE {
 		@Override
 		public double toBytes(double d) { return UnitInputValidator.requireNonNegativeFinite(d); }
@@ -48,10 +45,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Kibibyte (KiB)
-	 * 2^10 Byte = 1.024 Byte
-	 */
+	/** Kibibyte (KiB), equal to 2^10 bytes. */
 	KIB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_KIB); }
@@ -64,10 +58,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Mebibyte (MiB)
-	 * 2^20 Byte = 1.024 * 1.024 Byte = 1.048.576 Byte
-	 */
+	/** Mebibyte (MiB), equal to 2^20 bytes. */
 	MIB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_MIB); }
@@ -80,10 +71,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Gibibyte (GiB)
-	 * 2^30 Byte = 1.024 * 1.024 * 1.024 Byte = 1.073.741.824 Byte
-	 */
+	/** Gibibyte (GiB), equal to 2^30 bytes. */
 	GIB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_GIB); }
@@ -96,10 +84,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Tebibyte (TiB)
-	 * 2^40 Byte = 1.024 * 1.024 * 1.024 * 1.024 Byte = 1.099.511.627.776 Byte
-	 */
+	/** Tebibyte (TiB), equal to 2^40 bytes. */
 	TIB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_TIB); }
@@ -112,10 +97,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Pebibyte (PiB)
-	 * 2^50 Byte = 1.024 * 1.024 * 1.024 * 1.024 * 1.024 Byte = 1.125.899.906.842.624 Byte
-	 */
+	/** Pebibyte (PiB), equal to 2^50 bytes. */
 	PIB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_PIB); }
@@ -128,10 +110,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Kilobyte (kB)
-	 * 10^3 Byte = 1.000 Byte
-	 */
+	/** Kilobyte (kB), equal to 10^3 bytes. */
 	KB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_KB); }
@@ -144,10 +123,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Megabyte (MB)
-	 * 10^6 Byte = 1.000.000 Byte
-	 */
+	/** Megabyte (MB), equal to 10^6 bytes. */
 	MB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_MB); }
@@ -160,10 +136,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Gigabyte (GB)
-	 * 10^9 Byte = 1.000.000.000 Byte
-	 */
+	/** Gigabyte (GB), equal to 10^9 bytes. */
 	GB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_GB); }
@@ -176,10 +149,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Terabyte (TB)
-	 * 10^12 Byte = 1.000.000.000.000 Byte
-	 */
+	/** Terabyte (TB), equal to 10^12 bytes. */
 	TB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_TB); }
@@ -192,10 +162,7 @@ public enum ByteUnit {
 		}
 	},
 
-	/** <pre>
-	 * Petabyte (PB)
-	 * 10^15 Byte = 1.000.000.000.000.000 Byte
-	 */
+	/** Petabyte (PB), equal to 10^15 bytes. */
 	PB {
 		@Override
 		public double toBytes(double d) { return safeMulti(UnitInputValidator.requireNonNegativeFinite(d), C_PB); }


### PR DESCRIPTION
## Implementation Summary
- Scope: add a repeatable Maven Central release path for tagged non-SNAPSHOT releases.
- Key changes:
  - add required Central metadata (`url`, `licenses`, `developers`, `scm`) and a `release` profile that attaches sources/javadocs, signs artifacts, enforces release versions, and publishes through Sonatype's Central publishing plugin
  - flatten the deployed POM during release builds so published metadata resolves `${revision}` and excludes the GitHub Packages `pluginRepositories` entry
  - add a tag-triggered GitHub Actions workflow plus `RELEASING.md` and README release docs
  - fix malformed enum constant Javadocs so release Javadoc generation succeeds
  - ignore `.flattened-pom.xml` so local release builds do not pollute git status
- Non-goals:
  - provisioning the `media.barney` namespace in Sonatype Central
  - storing repository secrets for live publishing

## Validation
- Tests executed:
  - `./mvnw.cmd -B -ntp verify`
  - `./mvnw.cmd -B -ntp -Prelease -Drevision=0.1.0 -Dcentral.skipPublishing=true deploy` with a temporary local GPG key and temporary Maven settings
- Manual checks:
  - confirmed the release build produces `.asc` signatures for the main JAR, sources JAR, Javadoc JAR, and POM
  - confirmed Maven installs `.flattened-pom.xml` during the release build and that the installed POM contains `0.1.0` / `v0.1.0` without `pluginRepositories`
  - confirmed the Central publishing plugin is invoked in the release build
- Residual risks:
  - a live publish to Maven Central could not be executed because this repository currently has no configured Central credentials or GPG secrets
  - the `media.barney` namespace still has to be verified in the Central Publisher Portal before the workflow can publish successfully

Closes #21