### PR TITLE
#34 Remove explicit unit null wrappers

### DIFF
--- a/src/main/java/media/barney/utils/unit/BitUnit.java
+++ b/src/main/java/media/barney/utils/unit/BitUnit.java
@@ -17,7 +17,6 @@ package media.barney.utils.unit;
  * limitations under the License.
  */
 
-import java.util.Objects;
 
 /**
  * Defines binary (power-of-two) and decimal (power-of-ten) bit units and
@@ -37,9 +36,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toBits(value);
+			return u.toBits(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -50,9 +47,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toKibit(value);
+			return u.toKibit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -63,9 +58,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toMibit(value);
+			return u.toMibit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -76,9 +69,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toGibit(value);
+			return u.toGibit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -89,9 +80,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toTibit(value);
+			return u.toTibit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -102,9 +91,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toPibit(value);
+			return u.toPibit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -115,9 +102,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toKbit(value);
+			return u.toKbit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -128,9 +113,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toMbit(value);
+			return u.toMbit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -141,9 +124,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toGbit(value);
+			return u.toGbit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -154,9 +135,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toTbit(value);
+			return u.toTbit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -167,9 +146,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toPbit(value);
+			return u.toPbit(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	};
 
@@ -346,10 +323,7 @@ public enum BitUnit {
          * @return the converted value expressed in this unit
          */
         public final double convert(double d, ByteUnit u, int bitsPerByte){
-                ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-                double value = UnitInputValidator.requireNonNegativeFinite(d);
-                int validatedBitsPerByte = UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte);
-                double bits = safeMulti(sourceUnit.toBytes(value), validatedBitsPerByte);
+                double bits = safeMulti(u.toBytes(UnitInputValidator.requireNonNegativeFinite(d)), UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte));
                 return convert(bits, BIT);
         }
 

--- a/src/main/java/media/barney/utils/unit/BitUnit.java
+++ b/src/main/java/media/barney/utils/unit/BitUnit.java
@@ -36,7 +36,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toBits(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toBits(d);
 		}
 	},
 
@@ -47,7 +47,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toKibit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toKibit(d);
 		}
 	},
 
@@ -58,7 +58,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toMibit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toMibit(d);
 		}
 	},
 
@@ -69,7 +69,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toGibit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toGibit(d);
 		}
 	},
 
@@ -80,7 +80,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toTibit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toTibit(d);
 		}
 	},
 
@@ -91,7 +91,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toPibit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toPibit(d);
 		}
 	},
 
@@ -102,7 +102,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toKbit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toKbit(d);
 		}
 	},
 
@@ -113,7 +113,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toMbit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toMbit(d);
 		}
 	},
 
@@ -124,7 +124,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toGbit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toGbit(d);
 		}
 	},
 
@@ -135,7 +135,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toTbit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toTbit(d);
 		}
 	},
 
@@ -146,7 +146,7 @@ public enum BitUnit {
 
 		@Override
 		public double convert(double d, BitUnit u) {
-			return u.toPbit(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toPbit(d);
 		}
 	};
 
@@ -323,7 +323,7 @@ public enum BitUnit {
          * @return the converted value expressed in this unit
          */
         public final double convert(double d, ByteUnit u, int bitsPerByte){
-                double bits = safeMulti(u.toBytes(UnitInputValidator.requireNonNegativeFinite(d)), UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte));
+                double bits = safeMulti(u.toBytes(d), UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte));
                 return convert(bits, BIT);
         }
 

--- a/src/main/java/media/barney/utils/unit/ByteUnit.java
+++ b/src/main/java/media/barney/utils/unit/ByteUnit.java
@@ -17,7 +17,6 @@ package media.barney.utils.unit;
  * limitations under the License.
  */
 
-import java.util.Objects;
 
 /**
  * Defines binary (power-of-two) and decimal (power-of-ten) byte units and
@@ -41,9 +40,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toBytes(value);
+			return u.toBytes(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -54,9 +51,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toKiB(value);
+			return u.toKiB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -67,9 +62,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toMiB(value);
+			return u.toMiB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -80,9 +73,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toGiB(value);
+			return u.toGiB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -93,9 +84,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toTiB(value);
+			return u.toTiB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -106,9 +95,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toPiB(value);
+			return u.toPiB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -119,9 +106,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toKB(value);
+			return u.toKB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -132,9 +117,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toMB(value);
+			return u.toMB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -145,9 +128,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toGB(value);
+			return u.toGB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -158,9 +139,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toTB(value);
+			return u.toTB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	},
 
@@ -171,9 +150,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			ByteUnit sourceUnit = Objects.requireNonNull(u, "u");
-			double value = UnitInputValidator.requireNonNegativeFinite(d);
-			return sourceUnit.toPB(value);
+			return u.toPB(UnitInputValidator.requireNonNegativeFinite(d));
 		}
 	};
 
@@ -352,10 +329,7 @@ public enum ByteUnit {
          * @return the converted value expressed in this unit
          */
         public final double convert(double d, BitUnit u, int bitsPerByte){
-                BitUnit sourceUnit = Objects.requireNonNull(u, "u");
-                double value = UnitInputValidator.requireNonNegativeFinite(d);
-                int validatedBitsPerByte = UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte);
-                double bytes = sourceUnit.toBits(value) / validatedBitsPerByte;
+                double bytes = u.toBits(UnitInputValidator.requireNonNegativeFinite(d)) / UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte);
                 return convert(bytes, BYTE);
         }
 

--- a/src/main/java/media/barney/utils/unit/ByteUnit.java
+++ b/src/main/java/media/barney/utils/unit/ByteUnit.java
@@ -40,7 +40,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toBytes(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toBytes(d);
 		}
 	},
 
@@ -51,7 +51,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toKiB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toKiB(d);
 		}
 	},
 
@@ -62,7 +62,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toMiB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toMiB(d);
 		}
 	},
 
@@ -73,7 +73,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toGiB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toGiB(d);
 		}
 	},
 
@@ -84,7 +84,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toTiB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toTiB(d);
 		}
 	},
 
@@ -95,7 +95,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toPiB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toPiB(d);
 		}
 	},
 
@@ -106,7 +106,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toKB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toKB(d);
 		}
 	},
 
@@ -117,7 +117,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toMB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toMB(d);
 		}
 	},
 
@@ -128,7 +128,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toGB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toGB(d);
 		}
 	},
 
@@ -139,7 +139,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toTB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toTB(d);
 		}
 	},
 
@@ -150,7 +150,7 @@ public enum ByteUnit {
 
 		@Override
 		public double convert(double d, ByteUnit u) {
-			return u.toPB(UnitInputValidator.requireNonNegativeFinite(d));
+			return u.toPB(d);
 		}
 	};
 
@@ -329,7 +329,7 @@ public enum ByteUnit {
          * @return the converted value expressed in this unit
          */
         public final double convert(double d, BitUnit u, int bitsPerByte){
-                double bytes = u.toBits(UnitInputValidator.requireNonNegativeFinite(d)) / UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte);
+                double bytes = u.toBits(d) / UnitInputValidator.requirePositiveBitsPerByte(bitsPerByte);
                 return convert(bytes, BYTE);
         }
 

--- a/src/test/java/media/barney/utils/unit/BitUnitTest.java
+++ b/src/test/java/media/barney/utils/unit/BitUnitTest.java
@@ -221,4 +221,16 @@ class BitUnitTest {
                 () -> unit.convert(1d, (ByteUnit) null, Byte.SIZE))
             .forEach(executable -> assertThrows(NullPointerException.class, executable));
     }
+
+    @SuppressWarnings("NullAway")
+    @ParameterizedTest(name = "BitUnit keeps null-unit precedence for invalid value {0}")
+    @MethodSource("invalidValues")
+    @DisplayName("BitUnit null unit arguments still fail before invalid-value validation")
+    void nullUnitArgumentsStillFailFirstWhenValueIsInvalid(double value) {
+        Stream.of(
+                (Executable) () -> BitUnit.BIT.convert(value, (BitUnit) null),
+                () -> BitUnit.KIBIT.convert(value, (ByteUnit) null),
+                () -> BitUnit.MIBIT.convert(value, (ByteUnit) null, Byte.SIZE))
+            .forEach(executable -> assertThrows(NullPointerException.class, executable));
+    }
 }

--- a/src/test/java/media/barney/utils/unit/ByteUnitTest.java
+++ b/src/test/java/media/barney/utils/unit/ByteUnitTest.java
@@ -224,4 +224,16 @@ class ByteUnitTest {
                 () -> unit.convert(1d, (BitUnit) null, Byte.SIZE))
             .forEach(executable -> assertThrows(NullPointerException.class, executable));
     }
+
+    @SuppressWarnings("NullAway")
+    @ParameterizedTest(name = "ByteUnit keeps null-unit precedence for invalid value {0}")
+    @MethodSource("invalidValues")
+    @DisplayName("ByteUnit null unit arguments still fail before invalid-value validation")
+    void nullUnitArgumentsStillFailFirstWhenValueIsInvalid(double value) {
+        Stream.of(
+                (Executable) () -> ByteUnit.BYTE.convert(value, (ByteUnit) null),
+                () -> ByteUnit.KIB.convert(value, (BitUnit) null),
+                () -> ByteUnit.MIB.convert(value, (BitUnit) null, Byte.SIZE))
+            .forEach(executable -> assertThrows(NullPointerException.class, executable));
+    }
 }


### PR DESCRIPTION
## Implementation Summary
- Scope: remove explicit null-wrapper variables from ByteUnit and BitUnit conversion overloads while keeping the existing numeric argument validation intact.
- Key changes: direct enum method dispatch is now used for unit arguments, so null unit inputs still fail with NullPointerException naturally; no runtime validation rules for numeric arguments changed.
- Non-goals: no Validation API annotations or method-validation integration were added.

Closes #34

## Validation
- Tests executed: ./mvnw -B -ntp test, ./mvnw -B -ntp -Pnullaway test
- Manual checks: verified the null-unit regression tests still cover the public conversion entry points.
- Residual risks: none beyond standard enum conversion coverage already present in the test suite.