### PR TITLE
Remove crap-java GitHub Packages consumption

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: pr-tests-${{ github.event.pull_request.number || github.ref }}
@@ -20,9 +19,6 @@ jobs:
   test:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    env:
-      GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout
@@ -34,9 +30,6 @@ jobs:
           distribution: temurin
           java-version: "21"
           cache: maven
-          server-id: github
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
 
       - name: Run Maven test with NullAway
         run: ./mvnw -B -ntp -Pnullaway test
@@ -45,9 +38,6 @@ jobs:
     name: crap-java Gate
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
-    env:
-      GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout
@@ -59,9 +49,6 @@ jobs:
           distribution: temurin
           java-version: "21"
           cache: maven
-          server-id: github
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
 
       - name: Run crap-java gate
-        run: ./mvnw -B -ntp crap-java:check
+        run: ./mvnw -B -ntp verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -17,8 +16,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      GITHUB_ACTOR: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
       CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
       MAVEN_GPG_PASSPHRASE: ${{ secrets.CENTRAL_GPG_PASSPHRASE }}
@@ -62,11 +59,6 @@ jobs:
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                     xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
             <servers>
-              <server>
-                <id>github</id>
-                <username>${env.GITHUB_ACTOR}</username>
-                <password>${env.GITHUB_TOKEN}</password>
-              </server>
               <server>
                 <id>central</id>
                 <username>${env.CENTRAL_USERNAME}</username>

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -21,9 +21,6 @@ Configure these repository secrets:
 - `CENTRAL_GPG_PRIVATE_KEY`: ASCII-armored private key used to sign artifacts
 - `CENTRAL_GPG_PASSPHRASE`: passphrase for the private key
 
-The workflow also uses the built-in `GITHUB_TOKEN` to resolve the
-`crap-java-maven-plugin` from GitHub Packages.
-
 ## Release Process
 
 1. Make sure `main` contains the release-ready code.
@@ -48,7 +45,6 @@ You can validate the release profile locally without publishing by running:
 This still requires:
 
 - a usable GPG private key in the local keyring
-- access to GitHub Packages for the `crap-java-maven-plugin`
 
 ## Rollback Expectations
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <revision>0.0.1-SNAPSHOT</revision>
     <scm.tag>HEAD</scm.tag>
-    <crap-java.version>0.2.0</crap-java.version>
+    <crap-java.version>0.3.2</crap-java.version>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -45,16 +45,11 @@
     <central.autoPublish>true</central.autoPublish>
     <central.waitUntil>published</central.waitUntil>
     <central.skipPublishing>true</central.skipPublishing>
+    <jacoco.version>0.8.13</jacoco.version>
     <jspecify.version>1.0.0</jspecify.version>
     <errorprone.version>2.48.0</errorprone.version>
     <nullaway.version>0.13.1</nullaway.version>
   </properties>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>github</id>
-      <url>https://maven.pkg.github.com/fabian-barney/crap-java</url>
-    </pluginRepository>
-  </pluginRepositories>
   <dependencies>
     <dependency>
       <groupId>org.jspecify</groupId>
@@ -85,6 +80,25 @@
         <configuration>
           <useModulePath>false</useModulePath>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>media.barney</groupId>


### PR DESCRIPTION
﻿Closes #37.

## Summary
- upgrade the shared `media.barney.crap-java` Maven plugin to `0.3.2`
- remove the root `pluginRepositories` GitHub Packages configuration and related CI credentials
- generate JaCoCo XML during `verify` and run the `crap-java Gate` through `./mvnw -B -ntp verify`
