### PR TITLE
[codex] Upgrade crap-java to 0.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <revision>0.0.1-SNAPSHOT</revision>
     <scm.tag>HEAD</scm.tag>
-    <crap-java.version>0.4.1</crap-java.version>
+    <crap-java.version>0.5.0</crap-java.version>
     <cognitive-java.version>0.4.0</cognitive-java.version>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Closes #55

## What changed
- bump the shared `crap-java.version` property from `0.4.1` to `0.5.0`

## Validation
- `./mvnw.cmd -B -ntp "-P!quality-gates-all,quality-gate-crap" verify`