### PR TITLE
Fix #57 align CI stage families and quality gates

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maven-repository
-          path: ~/.m2/repository
+          path: /home/runner/.m2/repository
           if-no-files-found: error
 
       - name: Upload build outputs
@@ -75,7 +75,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ~/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -117,7 +117,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ~/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -153,7 +153,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ~/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -168,7 +168,7 @@ jobs:
           path: target/site/jacoco
 
       - name: Run crap-java gate
-        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap,nullaway verify
+        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap,nullaway -DskipTests verify
 
   quality-cognitive-utils-java:
     name: verify / quality-cognitive-utils-java
@@ -195,7 +195,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ~/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -210,4 +210,4 @@ jobs:
           path: target/site/jacoco
 
       - name: Run cognitive-java gate
-        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-cognitive,nullaway verify
+        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-cognitive,nullaway -DskipTests verify

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maven-repository
-          path: /home/runner/.m2/repository
+          path: ${{ runner.home }}/.m2/repository
           if-no-files-found: error
 
       - name: Upload build outputs
@@ -75,7 +75,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: /home/runner/.m2/repository
+          path: ${{ runner.home }}/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -117,7 +117,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: /home/runner/.m2/repository
+          path: ${{ runner.home }}/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -153,7 +153,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: /home/runner/.m2/repository
+          path: ${{ runner.home }}/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -195,7 +195,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: /home/runner/.m2/repository
+          path: ${{ runner.home }}/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: maven-repository
-          path: ${{ runner.home }}/.m2/repository
+          path: /home/runner/.m2/repository
           if-no-files-found: error
 
       - name: Upload build outputs
@@ -75,7 +75,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ${{ runner.home }}/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -117,7 +117,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ${{ runner.home }}/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -153,7 +153,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ${{ runner.home }}/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
@@ -195,7 +195,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: maven-repository
-          path: ${{ runner.home }}/.m2/repository
+          path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -84,7 +84,7 @@ jobs:
           path: target
 
       - name: Run unit tests
-        run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -o verify
+        run: ./mvnw -B -ntp -P!quality-gates-all,nullaway verify
 
       - name: Upload JaCoCo report
         uses: actions/upload-artifact@v4
@@ -126,7 +126,7 @@ jobs:
           path: target
 
       - name: Run package build
-        run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -o -DskipTests package
+        run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -DskipTests package
 
   quality-crap-utils-java:
     name: verify / quality-crap-utils-java
@@ -168,7 +168,7 @@ jobs:
           path: target/site/jacoco
 
       - name: Run crap-java gate
-        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap,nullaway -o verify
+        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap,nullaway verify
 
   quality-cognitive-utils-java:
     name: verify / quality-cognitive-utils-java
@@ -210,4 +210,4 @@ jobs:
           path: target/site/jacoco
 
       - name: Run cognitive-java gate
-        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-cognitive,nullaway -o verify
+        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-cognitive,nullaway verify

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -38,14 +38,14 @@ jobs:
         run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -DskipTests install
 
       - name: Upload Maven repository
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maven-repository
           path: ~/.m2/repository
           if-no-files-found: error
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-target
           path: target
@@ -72,13 +72,13 @@ jobs:
         run: chmod +x mvnw
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-target
           path: target
@@ -87,7 +87,7 @@ jobs:
         run: ./mvnw -B -ntp -P!quality-gates-all,nullaway verify
 
       - name: Upload JaCoCo report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-report
           path: target/site/jacoco
@@ -114,13 +114,13 @@ jobs:
         run: chmod +x mvnw
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-target
           path: target
@@ -150,19 +150,19 @@ jobs:
         run: chmod +x mvnw
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-target
           path: target
 
       - name: Download JaCoCo report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-report
           path: target/site/jacoco
@@ -192,19 +192,19 @@ jobs:
         run: chmod +x mvnw
 
       - name: Download Maven repository
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maven-repository
           path: ~/.m2/repository
 
       - name: Download build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: build-target
           path: target
 
       - name: Download JaCoCo report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: jacoco-report
           path: target/site/jacoco

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
+  build:
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
 
@@ -31,12 +31,31 @@ jobs:
           java-version: "21"
           cache: maven
 
-      - name: Run Maven test with NullAway
-        run: ./mvnw -B -ntp -Pnullaway test
+      - name: Set Maven wrapper permissions
+        run: chmod +x mvnw
 
-  crap-java:
-    name: crap-java Gate
+      - name: Build
+        run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -DskipTests install
+
+      - name: Upload Maven repository
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+          if-no-files-found: error
+
+      - name: Upload build outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-target
+          path: target
+          if-no-files-found: error
+
+  test-unit:
+    name: test / unit
     if: ${{ github.event.pull_request.draft == false }}
+    needs:
+      - build
     runs-on: ubuntu-latest
 
     steps:
@@ -48,14 +67,115 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
-          cache: maven
+      
+      - name: Set Maven wrapper permissions
+        run: chmod +x mvnw
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-target
+          path: target
+
+      - name: Run unit tests
+        run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -o verify
+
+      - name: Upload JaCoCo report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
+          if-no-files-found: error
+
+  package:
+    if: ${{ github.event.pull_request.draft == false }}
+    needs:
+      - build
+      - test-unit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set Maven wrapper permissions
+        run: chmod +x mvnw
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-target
+          path: target
+
+      - name: Run package build
+        run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -o -DskipTests package
+
+  quality-crap-utils-java:
+    name: verify / quality-crap-utils-java
+    if: ${{ github.event.pull_request.draft == false }}
+    needs:
+      - build
+      - test-unit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set Maven wrapper permissions
+        run: chmod +x mvnw
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-target
+          path: target
+
+      - name: Download JaCoCo report
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
 
       - name: Run crap-java gate
-        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap verify
+        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap,nullaway -o verify
 
-  cognitive-java:
-    name: cognitive-java Gate
+  quality-cognitive-utils-java:
+    name: verify / quality-cognitive-utils-java
     if: ${{ github.event.pull_request.draft == false }}
+    needs:
+      - build
+      - test-unit
     runs-on: ubuntu-latest
 
     steps:
@@ -67,7 +187,27 @@ jobs:
         with:
           distribution: temurin
           java-version: "21"
-          cache: maven
+
+      - name: Set Maven wrapper permissions
+        run: chmod +x mvnw
+
+      - name: Download Maven repository
+        uses: actions/download-artifact@v4
+        with:
+          name: maven-repository
+          path: ~/.m2/repository
+
+      - name: Download build outputs
+        uses: actions/download-artifact@v4
+        with:
+          name: build-target
+          path: target
+
+      - name: Download JaCoCo report
+        uses: actions/download-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
 
       - name: Run cognitive-java gate
-        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-cognitive verify
+        run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-cognitive,nullaway -o verify

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
   <properties>
     <revision>0.0.1-SNAPSHOT</revision>
     <scm.tag>HEAD</scm.tag>
-    <crap-java.version>0.3.2</crap-java.version>
+    <crap-java.version>0.5.0</crap-java.version>
     <cognitive-java.version>0.4.0</cognitive-java.version>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Summary
- align the CI workflow to the stage-family job layout
- split quality gates into targeted jobs and reuse build artifacts
- pin and wire the Java quality plugins for the new checks

## Validation
- ran the local Maven build, test, package, CRAP, and cognitive commands reflected in the workflow

Closes #57