### PR TITLE
chore(deps): update compatible Java quality plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
   <properties>
     <revision>0.0.1-SNAPSHOT</revision>
     <scm.tag>HEAD</scm.tag>
-    <crap-java.version>0.5.0</crap-java.version>
-    <cognitive-java.version>0.4.0</cognitive-java.version>
+    <crap-java.version>0.6.0</crap-java.version>
+    <cognitive-java.version>0.5.1</cognitive-java.version>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Closes #62

## Summary

- Updates Java quality plugin versions to compatible stable releases.
- Preserves Java 21.

## Validation

- .\\mvnw.cmd -B verify.

## Review Notes

- Dependency-only change; no public runtime floor was raised.
- Latest-compatible versions were selected over latest-absolute releases when framework or runtime constraints required it.