### PR TITLE
#58 Version policy audit: add Java 25 CI coverage

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -17,18 +17,23 @@ concurrency:
 
 jobs:
   build:
+    name: build / java ${{ matrix.java }}
     if: ${{ github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ["21", "25"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: ${{ matrix.java }}
           cache: maven
 
       - name: Set Maven wrapper permissions
@@ -40,47 +45,51 @@ jobs:
       - name: Upload Maven repository
         uses: actions/upload-artifact@v7
         with:
-          name: maven-repository
+          name: maven-repository-java-${{ matrix.java }}
           path: /home/runner/.m2/repository
           if-no-files-found: error
 
       - name: Upload build outputs
         uses: actions/upload-artifact@v7
         with:
-          name: build-target
+          name: build-target-java-${{ matrix.java }}
           path: target
           if-no-files-found: error
 
   test-unit:
-    name: test / unit
+    name: test / unit / java ${{ matrix.java }}
     if: ${{ github.event.pull_request.draft == false }}
     needs:
       - build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ["21", "25"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
-      
+          java-version: ${{ matrix.java }}
+
       - name: Set Maven wrapper permissions
         run: chmod +x mvnw
 
       - name: Download Maven repository
         uses: actions/download-artifact@v8
         with:
-          name: maven-repository
+          name: maven-repository-java-${{ matrix.java }}
           path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
         with:
-          name: build-target
+          name: build-target-java-${{ matrix.java }}
           path: target
 
       - name: Run unit tests
@@ -89,26 +98,31 @@ jobs:
       - name: Upload JaCoCo report
         uses: actions/upload-artifact@v7
         with:
-          name: jacoco-report
+          name: jacoco-report-java-${{ matrix.java }}
           path: target/site/jacoco
           if-no-files-found: error
 
   package:
+    name: package / java ${{ matrix.java }}
     if: ${{ github.event.pull_request.draft == false }}
     needs:
       - build
       - test-unit
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ["21", "25"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: ${{ matrix.java }}
 
       - name: Set Maven wrapper permissions
         run: chmod +x mvnw
@@ -116,35 +130,39 @@ jobs:
       - name: Download Maven repository
         uses: actions/download-artifact@v8
         with:
-          name: maven-repository
+          name: maven-repository-java-${{ matrix.java }}
           path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
         with:
-          name: build-target
+          name: build-target-java-${{ matrix.java }}
           path: target
 
       - name: Run package build
         run: ./mvnw -B -ntp -P!quality-gates-all,nullaway -DskipTests package
 
   quality-crap-utils-java:
-    name: verify / quality-crap-utils-java
+    name: verify / quality-crap-utils-java / java ${{ matrix.java }}
     if: ${{ github.event.pull_request.draft == false }}
     needs:
       - build
       - test-unit
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ["21", "25"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: ${{ matrix.java }}
 
       - name: Set Maven wrapper permissions
         run: chmod +x mvnw
@@ -152,41 +170,45 @@ jobs:
       - name: Download Maven repository
         uses: actions/download-artifact@v8
         with:
-          name: maven-repository
+          name: maven-repository-java-${{ matrix.java }}
           path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
         with:
-          name: build-target
+          name: build-target-java-${{ matrix.java }}
           path: target
 
       - name: Download JaCoCo report
         uses: actions/download-artifact@v8
         with:
-          name: jacoco-report
+          name: jacoco-report-java-${{ matrix.java }}
           path: target/site/jacoco
 
       - name: Run crap-java gate
         run: ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap,nullaway -DskipTests verify
 
   quality-cognitive-utils-java:
-    name: verify / quality-cognitive-utils-java
+    name: verify / quality-cognitive-utils-java / java ${{ matrix.java }}
     if: ${{ github.event.pull_request.draft == false }}
     needs:
       - build
       - test-unit
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: ["21", "25"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
+      - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: ${{ matrix.java }}
 
       - name: Set Maven wrapper permissions
         run: chmod +x mvnw
@@ -194,19 +216,19 @@ jobs:
       - name: Download Maven repository
         uses: actions/download-artifact@v8
         with:
-          name: maven-repository
+          name: maven-repository-java-${{ matrix.java }}
           path: /home/runner/.m2/repository
 
       - name: Download build outputs
         uses: actions/download-artifact@v8
         with:
-          name: build-target
+          name: build-target-java-${{ matrix.java }}
           path: target
 
       - name: Download JaCoCo report
         uses: actions/download-artifact@v8
         with:
-          name: jacoco-report
+          name: jacoco-report-java-${{ matrix.java }}
           path: target/site/jacoco
 
       - name: Run cognitive-java gate

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ It includes:
 
 ## Requirements
 
-- Java 21
+- Java 21 minimum
+- PR CI verifies compatibility with Java 21 and Java 25
 - Maven wrapper included in the repository
 
 ## Build


### PR DESCRIPTION
## Implementation Summary
- Scope: resolve issue #58 version policy audit findings for PR CI coverage and Java support documentation.
- Key changes: add Java 21/25 matrices across PR build, unit, package, and quality jobs; make CI artifacts Java-version-specific; document Java 21 as the minimum with Java 25 CI compatibility.
- Non-goals: no public API, library behavior, dependency, release, or artifact changes.

## Validation
- Tests executed: `.\mvnw.cmd -B -ntp verify`; `.\mvnw.cmd -B -ntp -Pnullaway test`; `.\mvnw.cmd -version`.
- Manual checks: `git diff --check`; wrapper distribution confirmed as Maven 3.9.16.
- Residual risks: local workflow schema linter was not available; PR checks validate the GitHub Actions matrix.

Closes #58