### PR TITLE
ci(release): use Maven Central secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     env:
-      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
-      CENTRAL_PASSWORD: ${{ secrets.CENTRAL_PASSWORD }}
-      MAVEN_GPG_PASSPHRASE: ${{ secrets.CENTRAL_GPG_PASSPHRASE }}
+      MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+      MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+      MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+      MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
     steps:
       - name: Checkout
@@ -47,8 +48,17 @@ jobs:
           distribution: temurin
           java-version: "21"
           cache: maven
-          gpg-private-key: ${{ secrets.CENTRAL_GPG_PRIVATE_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+
+      - name: Verify signing and publishing configuration
+        shell: bash
+        run: |
+          test -n "$MAVEN_CENTRAL_TOKEN_USERNAME"
+          test -n "$MAVEN_CENTRAL_TOKEN_PASSWORD"
+          test -n "$MAVEN_GPG_PRIVATE_KEY"
+          test -n "$MAVEN_GPG_PASSPHRASE"
+
+          printf '%s' "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
+          gpg --batch --list-secret-keys --keyid-format LONG
 
       - name: Write Maven settings.xml
         shell: bash
@@ -61,8 +71,8 @@ jobs:
             <servers>
               <server>
                 <id>central</id>
-                <username>${env.CENTRAL_USERNAME}</username>
-                <password>${env.CENTRAL_PASSWORD}</password>
+                <username>${env.MAVEN_CENTRAL_TOKEN_USERNAME}</username>
+                <password>${env.MAVEN_CENTRAL_TOKEN_PASSWORD}</password>
               </server>
             </servers>
           </settings>


### PR DESCRIPTION
## Summary
- switch Maven Central release workflow to the MAVEN_* secret names used by the other repositories
- import and list the configured GPG key before publishing so missing or malformed signing secrets fail early
- keep Maven Central credentials in settings.xml aligned with the MAVEN_* environment variables

## Validation
- `./mvnw.cmd -B -ntp "-P!quality-gates-all,nullaway" verify`

## Release note
This is release plumbing only. It enables the follow-up `v0.0.2` Maven Central publish without moving the failed historical `v0.0.1` tag.