### PR TITLE
build(release): use repository deployment name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
     <maven.enforcer.plugin.version>3.6.3</maven.enforcer.plugin.version>
     <central.publishing.plugin.version>0.11.0</central.publishing.plugin.version>
-    <central.deployment.repositoryName>utils-java</central.deployment.repositoryName>
+    <central.deployment.repository.name>utils-java</central.deployment.repository.name>
     <central.autoPublish>true</central.autoPublish>
     <central.waitUntil>published</central.waitUntil>
     <central.skipPublishing>true</central.skipPublishing>
@@ -282,7 +282,7 @@
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
-              <deploymentName>${project.groupId}:${central.deployment.repositoryName}:${project.version}</deploymentName>
+              <deploymentName>${project.groupId}:${central.deployment.repository.name}:${project.version}</deploymentName>
               <autoPublish>${central.autoPublish}</autoPublish>
               <waitUntil>${central.waitUntil}</waitUntil>
               <skipPublishing>${central.skipPublishing}</skipPublishing>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
     <maven.enforcer.plugin.version>3.6.3</maven.enforcer.plugin.version>
     <central.publishing.plugin.version>0.11.0</central.publishing.plugin.version>
+    <central.deployment.repositoryName>utils-java</central.deployment.repositoryName>
     <central.autoPublish>true</central.autoPublish>
     <central.waitUntil>published</central.waitUntil>
     <central.skipPublishing>true</central.skipPublishing>
@@ -281,6 +282,7 @@
             <extensions>true</extensions>
             <configuration>
               <publishingServerId>central</publishingServerId>
+              <deploymentName>${project.groupId}:${central.deployment.repositoryName}:${project.version}</deploymentName>
               <autoPublish>${central.autoPublish}</autoPublish>
               <waitUntil>${central.waitUntil}</waitUntil>
               <skipPublishing>${central.skipPublishing}</skipPublishing>


### PR DESCRIPTION
Closes #77

## Summary

- Adds a repo-local Central deployment-name property set to `utils-java`.
- Uses Sonatype `central-publishing-maven-plugin` `deploymentName` support to publish as
  `media.barney:utils-java:<version>`.
- Avoids unsupported dynamic naming, post-publish renames, OSSRH API workarounds, or publishing migrations.

## Review focus

- Confirm the visible Central deployment name uses the GitHub repo name as the middle segment.
- Confirm the change is limited to native Maven Central plugin configuration.

## Validation

- `./mvnw.cmd -B -ntp -Prelease "-Drevision=0.0.4" "-Dcentral.skipPublishing=true" help:effective-pom "-Doutput=target\effective-pom.xml"`
- Effective POM contains `media.barney:utils-java:0.0.4`.
- `./mvnw.cmd -B -ntp "-P!quality-gates-all,nullaway" -DskipTests install`
