### PR TITLE
ci(release): require imported secret signing key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,11 @@ jobs:
           test -n "$MAVEN_GPG_PASSPHRASE"
 
           printf '%s' "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
+          secret_key_count="$(gpg --batch --with-colons --list-secret-keys | awk -F: '$1 == "sec" { count++ } END { print count + 0 }')"
+          if [ "$secret_key_count" -eq 0 ]; then
+            echo "::error::MAVEN_GPG_PRIVATE_KEY did not import any secret keys." >&2
+            exit 1
+          fi
           gpg --batch --list-secret-keys --keyid-format LONG
 
       - name: Write Maven settings.xml


### PR DESCRIPTION
Closes #76

## Summary

- Keeps the existing `MAVEN_` release secret names.
- Fails the release preflight when `MAVEN_GPG_PRIVATE_KEY` imports no secret key.
- Keeps diagnostics limited to GPG secret-key metadata and avoids printing private material.

## Review focus

- Confirm public-key-only input cannot pass the preflight.
- Confirm the workflow still lists secret keys only after verifying at least one secret key exists.

## Validation

- Local Bash preflight test with generated GPG material passed.
- Public-key-only input returned the expected failure path.
- Generated test secret key input passed the secret-key-count assertion.
