### PR TITLE
chore: update compatible dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>6.1.0</version>
+      <version>6.1.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary

Updates JUnit from 6.1.0 to 6.1.1.

## Validation

`.\\mvnw.cmd -B verify` passed.

## Compatibility notes

Runtime floors are unchanged. Framework-managed dependency sets remain managed by
their framework/BOM where applicable. Maven 4 RC/plugin milestone and framework
minor/major migration candidates were intentionally not selected.

Closes #80
