### PR TITLE
Release v0.0.9: align release metadata and publication flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,10 @@ jobs:
               echo "::error::A published GitHub Release already exists for $GITHUB_REF_NAME." >&2
               exit 1
             fi
-            echo "A GitHub Release draft already exists for $GITHUB_REF_NAME."
+            gh release edit "$GITHUB_REF_NAME" \
+              --draft \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file "$notes_file"
           else
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,22 +111,66 @@ jobs:
             exit 1
           fi
 
-          existing_draft="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft 2>/dev/null || true)"
-          if [[ -n "$existing_draft" ]]; then
-            if [[ "$existing_draft" != "true" ]]; then
-              echo "::error::A published GitHub Release already exists for $GITHUB_REF_NAME." >&2
-              exit 1
+          release_error="$(mktemp)"
+          create_error="$(mktemp)"
+          trap 'rm -f "$notes_file" "$release_error" "$create_error"' EXIT
+
+          release_state=""
+          set +e
+          release_state="$(
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+              --jq .draft 2>"$release_error"
+          )"
+          release_status=$?
+          set -e
+
+          if [[ "$release_status" -ne 0 ]]; then
+            if grep -Eiq 'HTTP 404|Not Found' "$release_error"; then
+              release_state=""
+            else
+              cat "$release_error" >&2
+              exit "$release_status"
             fi
+          fi
+
+          refresh_draft() {
             gh release edit "$GITHUB_REF_NAME" \
               --draft \
               --title "$GITHUB_REF_NAME" \
               --notes-file "$notes_file"
+          }
+
+          if [[ -n "$release_state" ]]; then
+            if [[ "$release_state" != "true" ]]; then
+              echo "::error::A published GitHub Release already exists for $GITHUB_REF_NAME." >&2
+              exit 1
+            fi
+            refresh_draft
           else
+            set +e
             gh release create "$GITHUB_REF_NAME" \
               --verify-tag \
               --draft \
               --title "$GITHUB_REF_NAME" \
-              --notes-file "$notes_file"
+              --notes-file "$notes_file" 2>"$create_error"
+            create_status=$?
+            set -e
+
+            if [[ "$create_status" -ne 0 ]]; then
+              set +e
+              release_state="$(
+                gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+                  --jq .draft 2>"$release_error"
+              )"
+              release_status=$?
+              set -e
+              if [[ "$release_status" -eq 0 && "$release_state" == "true" ]]; then
+                refresh_draft
+              else
+                cat "$create_error" >&2
+                exit "$create_status"
+              fi
+            fi
           fi
 
       - name: Publish release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,10 @@ jobs:
       - name: Create GitHub Release draft
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
-          version="${GITHUB_REF_NAME#v}"
+          version="$RELEASE_VERSION"
           notes_file="$(mktemp)"
           awk -v version="$version" '
             /^## / {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -58,7 +58,10 @@ jobs:
           test -n "$MAVEN_GPG_PASSPHRASE"
 
           printf '%s' "$MAVEN_GPG_PRIVATE_KEY" | gpg --batch --import
-          secret_key_count="$(gpg --batch --with-colons --list-secret-keys | awk -F: '$1 == "sec" { count++ } END { print count + 0 }')"
+          secret_key_count="$(
+            gpg --batch --with-colons --list-secret-keys |
+              awk -F: '$1 == "sec" { count++ } END { print count + 0 }'
+          )"
           if [ "$secret_key_count" -eq 0 ]; then
             echo "::error::MAVEN_GPG_PRIVATE_KEY did not import any secret keys." >&2
             exit 1
@@ -72,7 +75,8 @@ jobs:
           cat > "${HOME}/.m2/settings.xml" <<'EOF'
           <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+                    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                        https://maven.apache.org/xsd/settings-1.0.0.xsd">
             <servers>
               <server>
                 <id>central</id>
@@ -83,5 +87,53 @@ jobs:
           </settings>
           EOF
 
+      - name: Create GitHub Release draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          notes_file="$(mktemp)"
+          awk -v version="$version" '
+            /^## / {
+              if (index($0, "## [" version "]") == 1 ||
+                  index($0, "## " version) == 1) {
+                in_release=1
+              } else if (in_release) {
+                exit
+              }
+            }
+            in_release { print }
+          ' CHANGELOG.md > "$notes_file"
+
+          if [[ ! -s "$notes_file" ]]; then
+            echo "::error::No changelog entry found for $GITHUB_REF_NAME." >&2
+            exit 1
+          fi
+
+          existing_draft="$(gh release view "$GITHUB_REF_NAME" --json isDraft --jq .isDraft 2>/dev/null || true)"
+          if [[ -n "$existing_draft" ]]; then
+            if [[ "$existing_draft" != "true" ]]; then
+              echo "::error::A published GitHub Release already exists for $GITHUB_REF_NAME." >&2
+              exit 1
+            fi
+            echo "A GitHub Release draft already exists for $GITHUB_REF_NAME."
+          else
+            gh release create "$GITHUB_REF_NAME" \
+              --verify-tag \
+              --draft \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file "$notes_file"
+          fi
+
       - name: Publish release
-        run: ./mvnw -B -ntp -Prelease -Drevision=${{ steps.version.outputs.version }} -Dscm.tag=v${{ steps.version.outputs.version }} -Dcentral.skipPublishing=false deploy
+        run: >
+          ./mvnw -B -ntp -Prelease
+          -Drevision=${{ steps.version.outputs.version }}
+          -Dscm.tag=v${{ steps.version.outputs.version }}
+          -Dcentral.skipPublishing=false deploy
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable releases of `utils-java` are documented here. The release workflow
+uses each versioned section as the authoritative GitHub Release notes.
+
+## [0.0.9] - 2026-08-09
+
+### Changed
+
+- aligned Maven Central deployment naming with the repository coordinates
+- hardened the tag-release signing preflight by verifying that a secret key was
+  imported
+- updated the GitHub Actions checkout and setup-java versions used by CI and
+  release automation
+- added automated GitHub Release draft creation and post-publication promotion
+
+### Compatibility
+
+- no public API or runtime behavior changes
+
+## [0.0.8] - 2026-08-08
+
+### Changed
+
+- updated the JSpecify dependency to 1.0.1

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ double bits = ByteUnit.KIB.toBits(4, 16);
 
 ## Release
 
-See `RELEASING.md` for the Maven Central release workflow, required GitHub
-secrets, and rollback expectations.
+See `CHANGELOG.md` for release history and `RELEASING.md` for the Maven Central
+workflow, required GitHub secrets, and rollback expectations.
 
 ## License
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,7 +1,8 @@
 # Releasing
 
 `utils-java` publishes non-`SNAPSHOT` releases to Maven Central through the
-Central Publisher Portal.
+Central Publisher Portal. `CHANGELOG.md` is the authoritative release-notes
+source used to create and publish the matching GitHub Release.
 
 ## Prerequisites
 
@@ -16,20 +17,26 @@ Before the release workflow can succeed:
 
 Configure these repository secrets:
 
-- `CENTRAL_USERNAME`: Central Publisher Portal user token username
-- `CENTRAL_PASSWORD`: Central Publisher Portal user token password
-- `CENTRAL_GPG_PRIVATE_KEY`: ASCII-armored private key used to sign artifacts
-- `CENTRAL_GPG_PASSPHRASE`: passphrase for the private key
+- `MAVEN_CENTRAL_TOKEN_USERNAME`: Central Publisher Portal user token username
+- `MAVEN_CENTRAL_TOKEN_PASSWORD`: Central Publisher Portal user token password
+- `MAVEN_GPG_PRIVATE_KEY`: ASCII-armored private key used to sign artifacts
+- `MAVEN_GPG_PASSPHRASE`: passphrase for the private key
 
 ## Release Process
 
-1. Make sure `main` contains the release-ready code.
-2. Create an annotated tag using the release version prefixed with `v`, for
-   example `v0.1.0`.
-3. Push the tag to GitHub.
+1. Make sure the release-ready code is merged into `main` and the working tree
+   is clean.
+2. Review the delta from the latest release and update the matching entry in
+   `CHANGELOG.md`. Scan for stale references with `git grep -F "v<previous>"`.
+3. Create an annotated tag using the release version prefixed with `v`, for
+   example `v0.1.0`, and push the tag to GitHub.
 4. The `Release to Maven Central` workflow derives the Maven version from the
-   tag, runs `./mvnw -Prelease deploy`, signs the artifacts, and publishes them
-   via the Central Publisher Portal.
+   tag, creates a GitHub Release draft from the matching changelog entry, runs
+   `./mvnw -Prelease deploy`, signs the artifacts, and publishes them via the
+   Central Publisher Portal.
+5. After Maven Central publication succeeds, the workflow promotes the GitHub
+   Release draft to a published release. If publication fails, retain the
+   draft and follow the immutable-version rollback policy below.
 
 The project keeps `0.0.1-SNAPSHOT` as the default local development version and
 overrides `revision` during tagged releases.
@@ -45,6 +52,21 @@ You can validate the release profile locally without publishing by running:
 This still requires:
 
 - a usable GPG private key in the local keyring
+
+Before tagging, review `THIRD_PARTY_NOTICES.md` and verify that dependency and
+transitive-license metadata remains accurate. The published runtime JAR does
+not bundle test or build-tool dependencies.
+
+## Publication Targets
+
+Maven Central is the only publication target for this repository. The Gradle
+Plugin Portal and private artifact repositories are not applicable.
+
+## Governance
+
+Release preparation must use a focused branch and pull request. Repository
+administrators should keep required reviews and status checks enabled on
+`main`; release tagging must not be used to bypass those gates.
 
 ## Rollback Expectations
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,7 +27,8 @@ Configure these repository secrets:
 1. Make sure the release-ready code is merged into `main` and the working tree
    is clean.
 2. Review the delta from the latest release and update the matching entry in
-   `CHANGELOG.md`. Scan for stale references with `git grep -F "v<previous>"`.
+   `CHANGELOG.md`. Set `previous_tag` to the actual prior tag and run
+   `git grep -F "$previous_tag"` to scan for stale references.
 3. Create an annotated tag using the release version prefixed with `v`, for
    example `v0.1.0`, and push the tag to GitHub.
 4. The `Release to Maven Central` workflow derives the Maven version from the

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,16 @@
+# Third-Party Notices
+
+The published `utils-java` runtime JAR contains only project classes and does
+not bundle third-party runtime code.
+
+## Provided dependency
+
+- `org.jspecify:jspecify:1.0.1` — Apache License 2.0. The dependency is declared
+  with Maven `provided` scope. See the [JSpecify project](https://jspecify.dev/)
+  and its [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0).
+
+## Test and build dependencies
+
+JUnit, Maven plugins, static-analysis tools, and other build-time dependencies
+are used only to build and verify this project. They are not bundled in the
+published runtime JAR or source distribution.


### PR DESCRIPTION
Closes #87

## Implementation Summary

- Scope: prepare the repository for the `v0.0.9` Maven Central maintenance
  release.
- Key changes: add authoritative changelog and third-party notices, align
  release-secret documentation, and create/promote GitHub Releases around the
  Maven Central publication step.
- Non-goals: no public API, runtime behavior, or Java support-matrix changes.

## Review Focus

- Inspect the GitHub Release draft extraction and idempotent retry behavior in
  `.github/workflows/release.yml`.
- Confirm the changelog section, Maven tag version, and final GitHub Release
  state remain aligned when publication succeeds or fails.
- `CHANGELOG.md` and `THIRD_PARTY_NOTICES.md` are new documentation sources.

## Validation

- Tests executed: `./mvnw.cmd -B -ntp clean verify` — 748 tests passed and both
  quality gates passed.
- Manual checks: quoted `v0.0.9` release-profile dry run passed through
  packaging, source/Javadoc generation, and Central skip behavior with a dummy
  server entry and GPG skipped.
- Residual risks: local signing could not run because this workstation has no
  configured GPG passphrase; the existing CI release run has already validated
  the configured signing path.
