### PR TITLE
#75 Audit unresolved Copilot review threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ On Windows:
 `verify` runs the library tests plus the shared `crap-java` and
 `cognitive-java` gates.
 
-To isolate only the `crap-java` gate on Unix-like systems:
+To run only the `crap-java` quality gate plugin while still executing the full
+Maven `verify` lifecycle on Unix-like systems:
 
 ```bash
 ./mvnw -B -ntp -P!quality-gates-all,quality-gate-crap verify
@@ -45,7 +46,8 @@ On Windows:
 .\mvnw.cmd -B -ntp -P!quality-gates-all,quality-gate-crap verify
 ```
 
-To isolate only the `cognitive-java` gate on Unix-like systems:
+To run only the `cognitive-java` quality gate plugin while still executing the
+full Maven `verify` lifecycle on Unix-like systems:
 
 ```bash
 ./mvnw -B -ntp -P!quality-gates-all,quality-gate-cognitive verify


### PR DESCRIPTION
Closes #75

## Implementation Summary
- Scope: audit the six historical review threads listed in issue #75.
- Key changes: clarify that the isolated quality-gate commands still execute
  Maven's full `verify` lifecycle; record evidence for the remaining thread
  classifications and the existing PR #79 fix.
- Non-goals: no Java, Maven profile, workflow, dependency, or public API
  changes.

## Validation
- Tests executed: `.\mvnw.cmd -B -ntp verify` (748 tests passed; both quality
  gates passed).
- Manual checks: `target/site/jacoco/jacoco.xml` was generated and
  `git diff --check` passed.
- Residual risks: none identified for the README-only change.
