### PR TITLE
Prepare and publish v0.0.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ uses each versioned section as the authoritative GitHub Release notes.
 
 ### Changed
 
-- clarified that the `quality-gate-*` Maven commands run the full `verify`
-  lifecycle
+- clarified that the `quality-gate-*` Maven commands run the full Maven
+  lifecycle through the `verify` phase
 - upgraded the CRAP quality plugin to 0.6.2 and the cognitive-complexity
   quality plugin to 0.7.0
 - upgraded the build-time NullAway analysis tool to 0.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ uses each versioned section as the authoritative GitHub Release notes.
 
 - clarified that the `quality-gate-*` Maven commands run the full `verify`
   lifecycle
-- upgraded the CRAP quality plugin to `0.6.2` and the cognitive-complexity
-  quality plugin to `0.7.0`
-- upgraded the build-time NullAway analysis tool to `0.14.0`
-- upgraded the GitHub Actions Java setup action to `6.0.0` in CI and release
+- upgraded the CRAP quality plugin to 0.6.2 and the cognitive-complexity
+  quality plugin to 0.7.0
+- upgraded the build-time NullAway analysis tool to 0.14.0
+- upgraded the GitHub Actions Java setup action to 6.0.0 in CI and release
   automation
 
 ### Compatibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable releases of `utils-java` are documented here. The release workflow
 uses each versioned section as the authoritative GitHub Release notes.
 
+## [0.0.11] - 2026-08-31
+
+### Changed
+
+- clarified that the `quality-gate-*` Maven commands run the full `verify`
+  lifecycle
+- upgraded the CRAP quality plugin to `0.6.2` and the cognitive-complexity
+  quality plugin to `0.7.0`
+- upgraded the build-time NullAway analysis tool to `0.14.0`
+- upgraded the GitHub Actions Java setup action to `6.0.0` in CI and release
+  automation
+
+### Compatibility
+
+- no public API or runtime behavior changes
+- the Java 21 release baseline remains unchanged
+
+## [0.0.10] - 2026-08-23
+
+### Changed
+
+- updated the JUnit Jupiter test dependency to 6.1.3
+
+### Compatibility
+
+- no public API or runtime behavior changes
+
 ## [0.0.9] - 2026-08-09
 
 ### Changed


### PR DESCRIPTION
Closes #100

## Implementation Summary

- Scope: prepare the next release after the merged dependency and workflow maintenance.
- Key changes: restore the published `0.0.10` history and add authoritative `0.0.11` notes.
- Non-goals: no public API, runtime, or Java support changes.

## Review Focus

- Confirm the changelog matches the commits after `v0.0.10`.
- Confirm version references and release metadata remain aligned.
- Confirm the release workflow remains the only publication path.

## Validation

- `clean verify`: passed; 748 tests passed with zero failures or errors.
- Explicit CRAP and cognitive profiles: passed without threshold properties.
- NullAway profile: passed.
- Threshold audit: no `crap-*` or `cognitive-*` override is configured.
- Dependency license and notice review: direct licenses and changed transitive scope reviewed.
- Release dry run: reached packaging and signing, then stopped because local GPG has no pinentry.

## Residual Risks

- Tag-triggered release signing and Maven Central publication must succeed with repository secrets.
- The local GPG pinentry limitation cannot validate signing on this workstation.
